### PR TITLE
65 total revenue merchant date

### DIFF
--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -28,9 +28,9 @@ class Api::V1::MerchantsController < ApplicationController
     render json: merchant.customers_pending_invoices
   end
 
-  # def most_items
-  #   render json: Merchant.most_items(params[:quantity])
-  # end
+  def most_items
+    render json: Merchant.most_items(params[:quantity])
+  end
 
   private
 

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -17,7 +17,11 @@ class Api::V1::MerchantsController < ApplicationController
   end
 
   def revenue
-    render json: merchant.total_revenue
+    if params[:date]
+      render json: merchant.total_revenue_for_date(params[:date])
+    else
+      render json: merchant.total_revenue
+    end
   end
 
   def pending_customers

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -18,7 +18,7 @@ class Merchant < ApplicationRecord
   end
 
   def self.most_items(number_of_records)
-    self.joins(invoices: [:transactions, :invoice_items]).
+    joins(invoices: [:transactions, :invoice_items]).
     where("transactions.result = 'success'").
     group("merchants.id").
     order("sum(invoice_items.quantity) DESC").
@@ -30,5 +30,11 @@ class Merchant < ApplicationRecord
     joins("INNER JOIN transactions on transactions.invoice_id=invoices.id").
     where("transactions.result='failed'").
     distinct
+  end
+
+  def total_revenue_for_date(date)
+    revenue = successful_invoice_items.where(invoices: {created_at: date}).
+    sum("invoice_items.quantity*CAST(invoice_items.unit_price AS integer)")
+    {"revenue" => (revenue/100.0).to_s}
   end
 end

--- a/spec/api/v1/business_logic/merchants_controller_spec.rb
+++ b/spec/api/v1/business_logic/merchants_controller_spec.rb
@@ -34,6 +34,6 @@ RSpec.describe "merchants controller" do
     data = JSON.parse(response.body)
 
     expect(data.count).to eq 2
-    expect(data.first["name"]).to eq merchant1.name
+    expect(data.first["name"]).to eq merchant2.name
   end
 end

--- a/spec/fixtures/invoice_items.yml
+++ b/spec/fixtures/invoice_items.yml
@@ -1,29 +1,36 @@
 one:
   item_id: 980190962
-  invoice_id: 980190962
-  quantity: 12
-  unit_price: 3.99
+  invoice: one
+  quantity: 1
+  unit_price: 100
+  created_at: 2012-03-27 14:53:59
 
 two:
   item_id: 980190962
-  invoice_id: 980190962
-  quantity: 12
-  unit_price: 3.99
+  invoice: one
+  quantity: 1
+  unit_price: 100
+  created_at: 2011-03-27 14:53:59
 
 three:
   item_id: 980190962
   invoice: one
-  quantity: 12
-  unit_price: 3.99
+  quantity: 1
+  unit_price: 100
+  created_at: 2011-03-27 14:53:59
+
 
 four:
   item_id: 980190962
   invoice: one
-  quantity: 12
-  unit_price: 3.99
+  quantity: 1
+  unit_price: 100
+  created_at: 2011-03-27 14:53:59
+
 
 five:
   item_id: 980190962
   invoice: three
   quantity: 12
   unit_price: 3.99
+  created_at: 2011-03-27 14:53:59

--- a/spec/fixtures/invoices.yml
+++ b/spec/fixtures/invoices.yml
@@ -2,6 +2,7 @@ one:
   status:      shipped
   customer_id: 980190962
   merchant: one
+  created_at: 2012-03-27 14:53:59
 
 two:
   status:      shipped

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Merchant, type: :model do
     invoice2 = create(:invoice, merchant: merchant)
 
     transaction1 = create(:transaction, result: "success", invoice: invoice1)
-    transaction1 = create(:transaction, result: "failed", invoice: invoice2)
+    transaction2 = create(:transaction, result: "failed", invoice: invoice2)
 
     invoice_item1 = create(:invoice_item, invoice: invoice1)
     invoice_item2 = create(:invoice_item, invoice: invoice1)
@@ -22,8 +22,8 @@ RSpec.describe Merchant, type: :model do
     merchant1 = merchants(:one)
     merchant2 = merchants(:two)
 
-    expect(Merchant.most_items(2).last).to eq merchant2
-    expect(Merchant.most_items(1).first).to eq merchant1
+    expect(Merchant.most_items(2).last).to eq merchant1
+    expect(Merchant.most_items(1).first).to eq merchant2
   end
 
   it "gets list of customers with pending invoices" do
@@ -34,5 +34,15 @@ RSpec.describe Merchant, type: :model do
     customer_pending_invoice = merchant.customers_pending_invoices.first
 
     expect(customer_pending_invoice).to eq(customer)
+  end
+
+  it "gets the total revenue for a merchant on a given date" do
+    merchant = merchants(:one)
+    invoice = invoices(:one)
+    invoice_item = invoice_items(:one)
+
+    date = "2012-03-27 14:53:59"
+
+    expect(merchant.total_revenue_for_date(date)).to eq ({"revenue" => "8.0"})
   end
 end


### PR DESCRIPTION
Add functionality to find total revenue for a given merchant by date 
and for finding a variable number of merchants ranked by number of items sold
